### PR TITLE
Feature/owner count

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/model/NamedEntity.java
+++ b/src/main/java/org/springframework/samples/petclinic/model/NamedEntity.java
@@ -18,6 +18,7 @@ package org.springframework.samples.petclinic.model;
 import jakarta.persistence.Column;
 import jakarta.persistence.MappedSuperclass;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 
 /**
  * Simple JavaBean domain object adds a name property to <code>BaseEntity</code>. Used as
@@ -32,6 +33,7 @@ public class NamedEntity extends BaseEntity {
 
 	@Column(name = "name")
 	@NotBlank
+    @Size(min = 3, max = 50)
 	private String name;
 
 	public String getName() {

--- a/src/main/java/org/springframework/samples/petclinic/owner/OwnerController.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/OwnerController.java
@@ -18,6 +18,8 @@ package org.springframework.samples.petclinic.owner;
 import java.util.List;
 import java.util.Optional;
 
+import jakarta.validation.Valid;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -32,8 +34,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.ModelAndView;
-
-import jakarta.validation.Valid;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 /**
@@ -169,5 +169,4 @@ class OwnerController {
 		mav.addObject(owner);
 		return mav;
 	}
-
 }

--- a/src/main/java/org/springframework/samples/petclinic/owner/OwnerRepository.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/OwnerRepository.java
@@ -15,10 +15,10 @@
  */
 package org.springframework.samples.petclinic.owner;
 
-import java.util.List;
 import java.util.Optional;
 
 import jakarta.annotation.Nonnull;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -61,5 +61,8 @@ public interface OwnerRepository extends JpaRepository<Owner, Integer> {
 	 * input for id)
 	 */
 	Optional<Owner> findById(@Nonnull Integer id);
+	
+	@Query("SELECT COUNT(o) FROM Owner o")
+	long countOwners();
 
 }

--- a/src/main/java/org/springframework/samples/petclinic/owner/OwnerRestController.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/OwnerRestController.java
@@ -1,0 +1,21 @@
+package org.springframework.samples.petclinic.owner;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/owners")
+public class OwnerRestController {
+
+    private final OwnerService ownerService;
+
+    public OwnerRestController(OwnerService ownerService) {
+        this.ownerService = ownerService;
+    }
+
+    @GetMapping("/count")
+    public long getOwnerCount() {
+        return ownerService.getOwnerCount();
+    }
+}

--- a/src/main/java/org/springframework/samples/petclinic/owner/OwnerService.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/OwnerService.java
@@ -1,0 +1,17 @@
+package org.springframework.samples.petclinic.owner;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class OwnerService {
+
+    private final OwnerRepository ownerRepository;
+
+    public OwnerService(OwnerRepository ownerRepository) {
+        this.ownerRepository = ownerRepository;
+    }
+
+    public long getOwnerCount() {
+        return ownerRepository.countOwners();
+    }
+}

--- a/src/main/java/org/springframework/samples/petclinic/owner/Pet.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/Pet.java
@@ -29,7 +29,6 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.OrderBy;
 import jakarta.persistence.Table;
-import jakarta.validation.constraints.Size;
 
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.samples.petclinic.model.NamedEntity;
@@ -45,9 +44,6 @@ import org.springframework.samples.petclinic.model.NamedEntity;
 @Entity
 @Table(name = "pets")
 public class Pet extends NamedEntity {
-	
-    @Size(min = 3, max = 50, message = "{pet.name.size}")
-    private String name;
 
 	@Column(name = "birth_date")
 	@DateTimeFormat(pattern = "yyyy-MM-dd")

--- a/src/main/java/org/springframework/samples/petclinic/owner/Pet.java
+++ b/src/main/java/org/springframework/samples/petclinic/owner/Pet.java
@@ -20,9 +20,6 @@ import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
-import org.springframework.format.annotation.DateTimeFormat;
-import org.springframework.samples.petclinic.model.NamedEntity;
-
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -32,6 +29,10 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.OrderBy;
 import jakarta.persistence.Table;
+import jakarta.validation.constraints.Size;
+
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.samples.petclinic.model.NamedEntity;
 
 /**
  * Simple business object representing a pet.
@@ -44,6 +45,9 @@ import jakarta.persistence.Table;
 @Entity
 @Table(name = "pets")
 public class Pet extends NamedEntity {
+	
+    @Size(min = 3, max = 50, message = "{pet.name.size}")
+    private String name;
 
 	@Column(name = "birth_date")
 	@DateTimeFormat(pattern = "yyyy-MM-dd")

--- a/src/main/java/org/springframework/samples/petclinic/system/WelcomeController.java
+++ b/src/main/java/org/springframework/samples/petclinic/system/WelcomeController.java
@@ -16,15 +16,25 @@
 
 package org.springframework.samples.petclinic.system;
 
+import org.springframework.samples.petclinic.owner.OwnerService;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 
 @Controller
 class WelcomeController {
+	
+    private final OwnerService ownerService;
 
-	@GetMapping("/")
-	public String welcome() {
-		return "welcome";
-	}
+    public WelcomeController(OwnerService ownerService) {
+        this.ownerService = ownerService;
+    }
+
+    @GetMapping("/")
+    public String welcome(Model model) {
+        long ownerCount = ownerService.getOwnerCount();
+        model.addAttribute("ownerCount", ownerCount);
+        return "welcome"; // welcome.html を表示
+    }
 
 }

--- a/src/main/resources/messages/messages.properties
+++ b/src/main/resources/messages/messages.properties
@@ -46,3 +46,4 @@ visitDate=Visit Date
 editOwner=Edit Owner
 addNewPet=Add New Pet
 petsAndVisits=Pets and Visits
+pet.name.size=ペットの名前は3文字以上50文字以内で入力してください

--- a/src/main/resources/templates/welcome.html
+++ b/src/main/resources/templates/welcome.html
@@ -4,12 +4,14 @@
 
 <body>
 
-  <h2 th:text="#{welcome}">Welcome</h2>
+  <h2 th:text="#{welcome}">Welcome</h2><p>登録されているオーナー数: <span th:text="${ownerCount}"></span></p>
   <div class="row">
     <div class="col-md-12">
       <img class="img-responsive" src="../static/resources/images/pets.png" th:src="@{/resources/images/pets.png}" />
     </div>
   </div>
+  
+  
 
 </body>
 

--- a/src/test/java/org/springframework/samples/petclinic/owner/OwnerRepositoryTest.java
+++ b/src/test/java/org/springframework/samples/petclinic/owner/OwnerRepositoryTest.java
@@ -1,0 +1,20 @@
+package org.springframework.samples.petclinic.owner;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+public class OwnerRepositoryTest {
+
+    @Autowired
+    private OwnerRepository ownerRepository;
+
+    @Test
+    void testCountOwners() {
+        long count = ownerRepository.count();
+        assertThat(count).isGreaterThan(0);  // データがあることを確認
+    }
+}

--- a/src/test/java/org/springframework/samples/petclinic/owner/OwnerRestControllerTest.java
+++ b/src/test/java/org/springframework/samples/petclinic/owner/OwnerRestControllerTest.java
@@ -1,0 +1,32 @@
+package org.springframework.samples.petclinic.owner;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(OwnerRestController.class)
+public class OwnerRestControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private OwnerService ownerService;
+
+    @Test
+    void testGetOwnerCountEndpoint() throws Exception {
+        when(ownerService.getOwnerCount()).thenReturn(10L);
+
+        mockMvc.perform(get("/api/owners/count"))
+               .andExpect(status().isOk())
+               .andExpect(content().string("10"));
+
+        verify(ownerService, times(1)).getOwnerCount();
+    }
+}

--- a/src/test/java/org/springframework/samples/petclinic/service/OwnerServiceTest.java
+++ b/src/test/java/org/springframework/samples/petclinic/service/OwnerServiceTest.java
@@ -1,0 +1,32 @@
+package org.springframework.samples.petclinic.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.samples.petclinic.owner.OwnerRepository;
+import org.springframework.samples.petclinic.owner.OwnerService;
+
+@ExtendWith(MockitoExtension.class)
+public class OwnerServiceTest {
+
+    @Mock
+    private OwnerRepository ownerRepository;
+
+    @InjectMocks
+    private OwnerService ownerService;
+
+    @Test
+    void testGetOwnerCount() {
+        when(ownerRepository.count()).thenReturn(5L);
+
+        long count = ownerService.getOwnerCount();
+
+        assertThat(count).isEqualTo(5L);
+        verify(ownerRepository, times(1)).count();
+    }
+}


### PR DESCRIPTION
【修正箇所】
Pet.javaのnameフィールドとバリデーションを削除し、
親クラスNamedEntity.javaクラスのnameフィールドにバリデーションを追加

【確認箇所】
＞＞「②2. フロントエンドでの表示は実装している？確認お願いします。」について
cloneしたPetclinicプロジェクトはHomeControllerの代わりにWelcomeControllerがトップページを担当していたので、
WelcomeControllerクラスでOwnerService を呼び出してオーナー数を取得し、Modelに値を渡す処理を記述し、
welcome.htmlにて取得したオーナー数を表示する記述をしています

=================================================================
src/main/java/org/springframework/samples/petclinic/system/WelcomeController.java
src/main/resources/templates/welcome.html
=================================================================